### PR TITLE
(Fixed) connection port error with ssl=False value

### DIFF
--- a/tinyxmpp/__init__.py
+++ b/tinyxmpp/__init__.py
@@ -84,7 +84,7 @@ class XMPPClient:
 
         self.ping_interval = ping_interval
         self.server_addr = host
-        self.server_port = port or 5223 if ssl else 5222
+        self.server_port = port or (5223 if ssl else 5222)
         self.ssl = ssl
         await self._connect()
 


### PR DESCRIPTION
There was bug. If make connection with connect(host="127.0.0.1", port=1488, ssl=False) connection will be to 127.0.0.1:5222. Fixed this.